### PR TITLE
Style game detail view with TI-84 inspired layout

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -482,73 +482,240 @@ button,
   flex: 1 1 150px;
 }
 
-.detail-layout {
+.detail-feature {
   display: grid;
   gap: clamp(2rem, 4vw, 3rem);
-  align-items: flex-start;
+  align-items: center;
 }
 
 @media (min-width: 900px) {
-  .detail-layout {
-    grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+  .detail-feature {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
   }
 }
 
-.detail-media {
+.detail-feature__visual {
   position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: clamp(1.5rem, 3vw, 2.2rem);
+  background:
+    radial-gradient(circle at 50% 12%, rgba(148, 197, 255, 0.2), transparent 64%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.78) 0%, rgba(2, 6, 23, 0.95) 100%);
   border-radius: var(--radius-lg);
-  overflow: hidden;
   box-shadow: var(--shadow-soft);
-  height: clamp(280px, 52vw, 520px);
-  background: #020b1f;
 }
 
-.detail-media::after {
+.detail-feature__visual::after {
   content: "";
   position: absolute;
-  inset: auto 0 0 0;
-  height: 55%;
-  background: linear-gradient(
-    180deg,
-    rgba(2, 6, 23, 0) 0%,
-    rgba(2, 6, 23, 0.45) 50%,
-    rgba(2, 6, 23, 0.92) 100%
-  );
+  inset: 4% 12% -12% 12%;
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.2), transparent 72%);
+  filter: blur(24px);
+  opacity: 0.6;
+  z-index: 0;
   pointer-events: none;
 }
 
-.detail-media img {
+.ti-device {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: min(100%, 360px);
+  margin: 0;
+  padding: clamp(1.6rem, 3vw, 2rem) clamp(1.8rem, 3.4vw, 2.4rem) clamp(3.6rem, 6vw, 4.4rem);
+  border-radius: 36px;
+  background: linear-gradient(180deg, #1e293b 0%, #111b2e 52%, #050b19 100%);
+  box-shadow: 0 30px 70px rgba(15, 23, 42, 0.58), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  z-index: 1;
+}
+
+.ti-device::before {
+  content: "";
   position: absolute;
   inset: 0;
-  display: block;
+  border-radius: 36px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), transparent 55%);
+  mix-blend-mode: screen;
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.ti-device__top {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.ti-device__brand {
+  font-weight: 600;
+}
+
+.ti-device__indicator {
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.85), rgba(29, 78, 216, 0.85));
+  color: #f8fafc;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  box-shadow: 0 4px 14px rgba(37, 99, 235, 0.4);
+}
+
+.ti-device__screen {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  margin-top: clamp(1.2rem, 2.8vw, 1.8rem);
+  padding: clamp(0.75rem, 2vw, 1rem);
+  border-radius: 22px;
+  background: linear-gradient(180deg, #091221 0%, #020615 100%);
+  box-shadow: inset 0 0 0 1px rgba(148, 197, 255, 0.15), inset 0 14px 24px rgba(59, 130, 246, 0.18);
+}
+
+.ti-device__screen-inner {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: 18px;
+  overflow: hidden;
+  background: radial-gradient(circle at 30% 30%, rgba(59, 130, 246, 0.14), rgba(15, 23, 42, 0.92));
+  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.5);
+}
+
+.ti-device__screen-inner::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 30% 30%, rgba(148, 197, 255, 0.24), transparent 62%),
+    repeating-linear-gradient(135deg, rgba(148, 163, 184, 0.12) 0, rgba(148, 163, 184, 0.12) 1px, transparent 1px, transparent 12px);
+  opacity: 0.75;
+  transition: opacity 0.35s ease;
+}
+
+.ti-device__screen-inner--has-image::after {
+  opacity: 0;
+}
+
+.ti-device__screen-inner img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  display: block;
+  position: relative;
+  z-index: 1;
 }
 
-.detail-body {
+.ti-device__divider {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: 4px;
+  margin-top: clamp(1.3rem, 3vw, 1.8rem);
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.12), rgba(71, 85, 105, 0.6), rgba(148, 163, 184, 0.12));
+  opacity: 0.65;
+}
+
+.ti-device__controls {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  margin-top: clamp(1.2rem, 3vw, 2rem);
+  padding: clamp(1.6rem, 3.4vw, 2.4rem) clamp(1.2rem, 3vw, 2rem) clamp(2.4rem, 4vw, 3.2rem);
+  border-radius: 26px 26px 22px 22px;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.92) 0%, rgba(2, 6, 23, 0.98) 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), inset 0 -10px 30px rgba(2, 6, 23, 0.7);
+  overflow: hidden;
+}
+
+.ti-device__controls::before {
+  content: "";
+  position: absolute;
+  inset: 1rem 1.4rem 1.2rem;
+  background-image: radial-gradient(rgba(226, 232, 240, 0.09) 40%, transparent 42%);
+  background-size: 1.55rem 1.55rem;
+  opacity: 0.85;
+}
+
+.ti-device__controls::after {
+  content: "";
+  position: absolute;
+  inset: auto 30% -28% 30%;
+  background: radial-gradient(ellipse at center, rgba(15, 23, 42, 0.7), transparent 70%);
+  opacity: 0.8;
+}
+
+.detail-feature__body {
+  position: relative;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  padding: clamp(1.5rem, 3vw, 2rem);
+  padding: clamp(1.8rem, 3vw, 2.4rem);
   box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1rem;
 }
 
-.detail-body h1 {
-  margin-top: 0;
-  margin-bottom: 0.75rem;
-  font-size: clamp(2rem, 4vw, 2.6rem);
+.detail-feature__body::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.16), transparent 55%);
+  opacity: 0.4;
+  pointer-events: none;
 }
 
-.detail-body p {
+.detail-feature__body h1 {
+  position: relative;
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.65rem);
+  color: var(--text-primary);
+}
+
+.detail-feature__body p {
+  position: relative;
+  margin: 0;
   color: var(--text-secondary);
-  margin-bottom: 1rem;
+  line-height: 1.7;
 }
 
-.detail-body .button-group {
+.detail-feature__eyebrow {
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 255, 0.75);
+  line-height: 1.2;
+}
+
+.detail-feature__description {
+  position: relative;
+  display: grid;
+  gap: 1rem;
+  color: var(--text-secondary);
+}
+
+.detail-feature__description p {
+  margin: 0;
+}
+
+.detail-feature__body .button-group {
+  position: relative;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.85rem;
   margin-top: 1.5rem;
 }
 

--- a/public/games/detail/index.html
+++ b/public/games/detail/index.html
@@ -42,15 +42,27 @@
 
     <section class="page-section js-reveal">
         <div class="content-container">
-            <div class="detail-layout" id="game-detail">
-                <div class="detail-media js-reveal">
-                    <img id="game-image" src="" alt="" loading="lazy">
+            <article class="detail-feature" id="game-detail">
+                <div class="detail-feature__visual js-reveal">
+                    <figure class="ti-device" id="ti-device" aria-label="TI-84 Plus CE preview">
+                        <div class="ti-device__top">
+                            <span class="ti-device__brand">TI-84 Plus CE</span>
+                            <span class="ti-device__indicator">TI-84</span>
+                        </div>
+                        <div class="ti-device__screen">
+                            <div class="ti-device__screen-inner">
+                                <img id="game-image" src="" alt="" loading="lazy" hidden>
+                            </div>
+                        </div>
+                        <div class="ti-device__divider" aria-hidden="true"></div>
+                        <div class="ti-device__controls" aria-hidden="true"></div>
+                    </figure>
                 </div>
-                <div class="detail-body js-reveal" id="game-info">
+                <div class="detail-feature__body js-reveal" id="game-info">
                     <h1>Loading…</h1>
                     <p>Please hold on while we fetch the latest description and download links.</p>
                 </div>
-            </div>
+            </article>
         </div>
     </section>
 </main>
@@ -117,6 +129,8 @@
         const heroSubtitle = document.getElementById('hero-subtitle');
         const image = document.getElementById('game-image');
         const info = document.getElementById('game-info');
+        const deviceFigure = document.getElementById('ti-device');
+        const screenInner = image.closest('.ti-device__screen-inner');
 
         document.title = `${game.title} · Calculator Games`;
         heroTitle.textContent = game.title;
@@ -124,13 +138,20 @@
 
         image.src = game.image;
         image.alt = `${game.title} screenshot`;
+        image.hidden = false;
+        if (screenInner) {
+            screenInner.classList.add('ti-device__screen-inner--has-image');
+        }
+        if (deviceFigure) {
+            deviceFigure.setAttribute('aria-label', `TI-84 Plus CE showing ${game.title}`);
+        }
 
         const safeDescription = game.description || 'This title is still being described. Check the download link for more info.';
 
         info.innerHTML = `
+            <p class="detail-feature__eyebrow">By ${game.author}</p>
             <h1>${game.title}</h1>
-            <p><strong>Author:</strong> ${game.author}</p>
-            <p>${safeDescription}</p>
+            <div class="detail-feature__description">${safeDescription}</div>
             ${buildButtonGroup(game)}
         `;
     }
@@ -140,12 +161,21 @@
         const heroSubtitle = document.getElementById('hero-subtitle');
         const info = document.getElementById('game-info');
         const image = document.getElementById('game-image');
+        const deviceFigure = document.getElementById('ti-device');
+        const screenInner = image.closest('.ti-device__screen-inner');
 
         document.title = 'Game not found · Calculator Games';
         heroTitle.textContent = 'Game not found';
         heroSubtitle.textContent = 'The game you are looking for could not be located.';
         image.removeAttribute('src');
         image.alt = '';
+        image.hidden = true;
+        if (screenInner) {
+            screenInner.classList.remove('ti-device__screen-inner--has-image');
+        }
+        if (deviceFigure) {
+            deviceFigure.setAttribute('aria-label', 'TI-84 Plus CE preview');
+        }
 
         info.innerHTML = `
             <h1>We could not load this game</h1>


### PR DESCRIPTION
## Summary
- restyle the game detail hero to showcase a TI-84 inspired device frame around screenshots
- enrich the detail copy with an author eyebrow, improved description layout, and accessible aria labels
- add CSS for the calculator frame, dynamic screen placeholder, and refreshed detail panel styling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ce0fc3adc0833087f3906ec1f3d870