### PR TITLE
Adjust detail page image sizing

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -537,8 +537,10 @@ button,
   border-radius: var(--radius-lg);
   overflow: hidden;
   box-shadow: var(--shadow-soft);
-  height: clamp(100%, 100%, 100%);
   background: #020b1f;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .detail-media::after {
@@ -556,12 +558,11 @@ button,
 }
 
 .detail-media img {
-  position: absolute;
-  inset: 0;
+  position: relative;
   display: block;
   width: 100%;
-  height: 100%;
-  object-fit: cover;
+  height: auto;
+  object-fit: contain;
 }
 
 .detail-body {


### PR DESCRIPTION
## Summary
- center the detail page media container content so screenshots can use their full natural dimensions
- switch the detail image to use `object-fit: contain` so it is displayed at full height without cropping

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce1966b5cc8330b148feb1bc30ccc6